### PR TITLE
Create structure for requests

### DIFF
--- a/docs/architecture-decisions/0004-use-arrays-for-mapping-schema.md
+++ b/docs/architecture-decisions/0004-use-arrays-for-mapping-schema.md
@@ -1,0 +1,58 @@
+# 4. Use arrays for mapping schema
+
+Date: 2018-09-02
+
+## Status
+
+Accepted
+
+## Context
+
+The Java implementation of the protocol uses `final static` properties to define
+the schema for requests and responses. These are defined using objects, making
+it easy to support multiple versions for each API call.
+
+PHP doesn't have this feature so we need decide how to solve this.
+
+## Decision
+
+We're still going to use objects to manipulate data and write/read content
+to/from Kafka, however it would be simpler to use arrays in constants of each
+request/response class.
+
+Each field would be an array item, the key would be the field name and the value
+would be the field type (or another array for more complex configuration).
+
+The mapping would like this:
+
+```php
+use Lcobucci\Kafka\Protocol\Type;
+
+final class DoSomethingRequest
+{
+    private const SCHEMAS = [
+        [
+            'error_code'   => Type\Int16::class,
+            'api_versions' => [
+                'type'     => Type\ArrayOf::class,
+                'nullable' => false, // optional, default = false
+                'items'    => [ // just type name if items don't have complex structure
+                    'api_key'     => Type\Int16::class,
+                    'min_version' => Type\Int16::class,
+                    'max_version' => Type\Int16::class,
+                ],
+            ],
+        ],
+    ];
+}
+```
+
+## Consequences
+
+We'd need to create something to build the schema from an array, which allow us
+to reuse instances of simple types.
+
+A minor drawback is that the structure of the array should be validated in order
+to create the correct schema, but since is an internal process there's no real
+reason to worry about it.
+

--- a/docs/architecture-decisions/README.md
+++ b/docs/architecture-decisions/README.md
@@ -3,3 +3,4 @@
 * [1. Record architecture decisions](0001-record-architecture-decisions.md)
 * [2. Require PHP 7.2 (64-bit)](0002-require-php-7-2-64-bit.md)
 * [3. Port protocol's types from Java implementation](0003-port-protocol-s-types-from-java-implementation.md)
+* [4. Use arrays for mapping schema](0004-use-arrays-for-mapping-schema.md)

--- a/src/Protocol/Schema.php
+++ b/src/Protocol/Schema.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\Kafka\Protocol;
+
+use Lcobucci\Kafka\Protocol\Schema\Field;
+use function assert;
+use function is_array;
+
+/**
+ * Represents the fields present in a specific version of a protocol message (request or response)
+ */
+final class Schema extends Type
+{
+    /**
+     * @var Field[]
+     */
+    private $fields;
+
+    public function __construct(Field ...$fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($data, Message $message): void
+    {
+        assert(is_array($data));
+
+        foreach ($this->fields as $field) {
+            $field->writeTo($data, $message);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read(Message $message): array
+    {
+        $structure = [];
+
+        foreach ($this->fields as $field) {
+            $structure[$field->name()] = $field->readFrom($message);
+        }
+
+        return $structure;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sizeOf($data): int
+    {
+        assert(is_array($data));
+
+        $size = 0;
+
+        foreach ($this->fields as $field) {
+            $size += $field->sizeOf($data);
+        }
+
+        return $size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($data): void
+    {
+        $this->guardAgainstNull($data, 'array');
+        $this->guardType($data, 'array', 'is_array');
+
+        foreach ($this->fields as $field) {
+            $this->validateField($data, $field);
+        }
+    }
+
+    /**
+     * @param mixed[] $data
+     *
+     * @throws SchemaValidationFailure When value is not valid for given field.
+     */
+    private function validateField(array $data, Field $field): void
+    {
+        try {
+            $field->validate($data);
+        } catch (SchemaValidationFailure $failure) {
+            throw SchemaValidationFailure::invalidValueForField($field->name(), $failure);
+        }
+    }
+}

--- a/src/Protocol/Schema/Field.php
+++ b/src/Protocol/Schema/Field.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\Kafka\Protocol\Schema;
+
+use Lcobucci\Kafka\Protocol\Message;
+use Lcobucci\Kafka\Protocol\NotEnoughBytesAllocated;
+use Lcobucci\Kafka\Protocol\SchemaValidationFailure;
+use Lcobucci\Kafka\Protocol\Type;
+
+/**
+ * Represents a field of a message
+ */
+final class Field
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var Type
+     */
+    private $type;
+
+    public function __construct(string $name, Type $type)
+    {
+        $this->name = $name;
+        $this->type = $type;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Writes content to the message using field type
+     *
+     * @param mixed[] $structure
+     *
+     * @throws SchemaValidationFailure When field is not nullable and missing from the structure.
+     * @throws NotEnoughBytesAllocated When size of given value is bigger than the remaining allocated bytes.
+     */
+    public function writeTo(array $structure, Message $message): void
+    {
+        $this->type->write($this->extractValue($structure), $message);
+    }
+
+    /**
+     * Reads content from message using field type
+     *
+     * @return mixed
+     *
+     * @throws NotEnoughBytesAllocated When trying to read a content bigger than the remaining allocated bytes.
+     */
+    public function readFrom(Message $message)
+    {
+        return $this->type->read($message);
+    }
+
+    /**
+     * Returns the number of bytes necessary for this field
+     *
+     * @param mixed[] $structure
+     *
+     * @throws SchemaValidationFailure When field is not nullable and missing from the structure.
+     */
+    public function sizeOf(array $structure): int
+    {
+        return $this->type->sizeOf($this->extractValue($structure));
+    }
+
+    /**
+     * Ensures that given data is valid
+     *
+     * @param mixed[] $structure
+     *
+     * @throws SchemaValidationFailure When field is not nullable and missing from the structure, or data is invalid.
+     */
+    public function validate(array $structure): void
+    {
+        $this->type->validate($this->extractValue($structure));
+    }
+
+    /**
+     * Returns the value for the field, falling back to null (when possible)
+     *
+     * @param mixed[] $structure
+     *
+     * @return mixed
+     *
+     * @throws SchemaValidationFailure When field is not nullable and missing from the structure.
+     */
+    private function extractValue(array $structure)
+    {
+        if (! isset($structure[$this->name]) && ! $this->type->isNullable()) {
+            throw SchemaValidationFailure::missingField($this->name);
+        }
+
+        return $structure[$this->name] ?? null;
+    }
+}

--- a/src/Protocol/SchemaValidationFailure.php
+++ b/src/Protocol/SchemaValidationFailure.php
@@ -56,4 +56,13 @@ final class SchemaValidationFailure extends RuntimeException implements Exceptio
             sprintf('Field "%s" missing from given structure', $name)
         );
     }
+
+    public static function invalidValueForField(string $name, SchemaValidationFailure $failure): self
+    {
+        return new self(
+            sprintf('Invalid value for field "%s": %s', $name, $failure->getMessage()),
+            0,
+            $failure
+        );
+    }
 }

--- a/src/Protocol/SchemaValidationFailure.php
+++ b/src/Protocol/SchemaValidationFailure.php
@@ -49,4 +49,11 @@ final class SchemaValidationFailure extends RuntimeException implements Exceptio
             sprintf('String length (%d) is larger than the maximum length (%d)', $length, $maxLength)
         );
     }
+
+    public static function missingField(string $name): self
+    {
+        return new self(
+            sprintf('Field "%s" missing from given structure', $name)
+        );
+    }
 }

--- a/tests/Unit/Protocol/Schema/FieldTest.php
+++ b/tests/Unit/Protocol/Schema/FieldTest.php
@@ -1,0 +1,197 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\Kafka\Test\Unit\Protocol\Schema;
+
+use Lcobucci\Kafka\Protocol\Message;
+use Lcobucci\Kafka\Protocol\Schema\Field;
+use Lcobucci\Kafka\Protocol\SchemaValidationFailure;
+use Lcobucci\Kafka\Protocol\Type\Int8;
+use Lcobucci\Kafka\Protocol\Type\NullableString;
+use PHPUnit\Framework\TestCase;
+use function pack;
+
+/**
+ * @coversDefaultClass \Lcobucci\Kafka\Protocol\Schema\Field
+ */
+final class FieldTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::name
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function nameShouldReturnTheFieldName(): void
+    {
+        $field = new Field('testing', new Int8());
+
+        self::assertSame('testing', $field->name());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::writeTo
+     * @covers ::extractValue
+     * @covers \Lcobucci\Kafka\Protocol\SchemaValidationFailure::missingField
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function writeToShouldRaiseExceptionWhenFieldIsMissing(): void
+    {
+        $field = new Field('testing', new Int8());
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('Field "testing" missing from given structure');
+
+        $field->writeTo([], Message::allocate(1));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::writeTo
+     * @covers ::extractValue
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function writeToShouldUseTypeToWriteIntoMessage(): void
+    {
+        $type  = new Int8();
+        $field = new Field('testing', $type);
+
+        $message = Message::allocate(1);
+        $field->writeTo(['testing' => 10], $message);
+        $message->reset();
+
+        self::assertSame(10, $type->read($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::writeTo
+     * @covers ::extractValue
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\NullableString
+     */
+    public function writeToShoulNotRaiseExceptionWhenFieldIsMissingButTypeIsNullable(): void
+    {
+        $type  = new NullableString();
+        $field = new Field('testing', $type);
+
+        $message = Message::allocate(2);
+        $field->writeTo([], $message);
+        $message->reset();
+
+        self::assertNull($type->read($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::readFrom
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function readFromShouldUseTheTypeToReadFromTheMessage(): void
+    {
+        $message = Message::fromContent(pack('c', 10));
+        $field   = new Field('testing', new Int8());
+
+        self::assertSame(10, $field->readFrom($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::sizeOf
+     * @covers ::extractValue
+     * @covers \Lcobucci\Kafka\Protocol\SchemaValidationFailure::missingField
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function sizeOfShouldRaiseExceptionWhenFieldIsMissing(): void
+    {
+        $field = new Field('testing', new Int8());
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('Field "testing" missing from given structure');
+
+        $field->sizeOf([]);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::sizeOf
+     * @covers ::extractValue
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function sizeOfShouldUseTypeToTheCalculateSize(): void
+    {
+        $type  = new Int8();
+        $field = new Field('testing', $type);
+
+        self::assertSame($type->sizeOf(10), $field->sizeOf(['testing' => 10]));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     * @covers ::extractValue
+     * @covers \Lcobucci\Kafka\Protocol\SchemaValidationFailure::missingField
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function validateShouldRaiseExceptionWhenFieldIsMissing(): void
+    {
+        $field = new Field('testing', new Int8());
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('Field "testing" missing from given structure');
+
+        $field->validate([]);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     * @covers ::extractValue
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\SchemaValidationFailure::incorrectRange
+     */
+    public function validateShouldUseTypeToPerformValidation(): void
+    {
+        $field = new Field('testing', new Int8());
+
+        $field->validate(['testing' => 10]);
+
+        $this->expectException(SchemaValidationFailure::class);
+        $field->validate(['testing' => 130]);
+    }
+}

--- a/tests/Unit/Protocol/SchemaTest.php
+++ b/tests/Unit/Protocol/SchemaTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\Kafka\Test\Unit\Protocol;
+
+use Lcobucci\Kafka\Protocol\Message;
+use Lcobucci\Kafka\Protocol\Schema;
+use Lcobucci\Kafka\Protocol\SchemaValidationFailure;
+use Lcobucci\Kafka\Protocol\Type\Int8;
+use Lcobucci\Kafka\Protocol\Type\NonNullableString;
+use Lcobucci\Kafka\Protocol\Type\NullableString;
+use PHPUnit\Framework\TestCase;
+use function pack;
+
+/**
+ * @coversDefaultClass \Lcobucci\Kafka\Protocol\Schema
+ */
+final class SchemaTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::write
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function writeShouldGoThroughEveryFieldAndAddDataToMessage(): void
+    {
+        $message = Message::allocate(2);
+        $field1  = new Schema\Field('test1', new Int8());
+        $field2  = new Schema\Field('test2', new Int8());
+
+        $schema = new Schema($field1, $field2);
+        $schema->write(['test2' => 10, 'test1' => 1], $message);
+
+        $message->reset();
+
+        self::assertSame(1, $field1->readFrom($message));
+        self::assertSame(10, $field2->readFrom($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::read
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     */
+    public function readShouldUseFieldDataToParseMessage(): void
+    {
+        $message = Message::fromContent(pack('c2', 1, 10));
+        $schema  = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new Int8())
+        );
+
+        self::assertSame(['test1' => 1, 'test2' => 10], $schema->read($message));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::sizeOf
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Message
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\Type\NonNullableString
+     */
+    public function sizeOfShouldReturnTheNumberOfBytesNeededForEveryFieldInSchema(): void
+    {
+        $schema = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new NonNullableString())
+        );
+
+        self::assertSame(7, $schema->sizeOf(['test1' => 1, 'test2' => 'test']));
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     * @covers ::validateField
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\Type\NullableString
+     */
+    public function validateShouldNotRaiseExceptionWhenValueIsAnArrayWithAllRequiredValues(): void
+    {
+        $schema = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new NullableString())
+        );
+
+        $schema->validate(['test1' => 1, 'test2' => 'test']);
+        $schema->validate(['test1' => 1, 'test2' => null]);
+        $schema->validate(['test1' => 1]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\SchemaValidationFailure
+     */
+    public function validateShouldRaiseExceptionWhenValueIsNull(): void
+    {
+        $schema = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new Int8())
+        );
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('null');
+
+        $schema->validate(null);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\SchemaValidationFailure
+     */
+    public function validateShouldRaiseExceptionWhenValueIsNotAnArray(): void
+    {
+        $schema = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new Int8())
+        );
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('array');
+
+        $schema->validate(true);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::validate
+     * @covers ::validateField
+     * @covers \Lcobucci\Kafka\Protocol\SchemaValidationFailure::invalidValueForField
+     *
+     * @uses \Lcobucci\Kafka\Protocol\Schema\Field
+     * @uses \Lcobucci\Kafka\Protocol\Type
+     * @uses \Lcobucci\Kafka\Protocol\Type\Int8
+     * @uses \Lcobucci\Kafka\Protocol\SchemaValidationFailure
+     */
+    public function validateShouldRaiseExceptionWhenValueOfOneOfTheFieldsIsInvalid(): void
+    {
+        $schema = new Schema(
+            new Schema\Field('test1', new Int8()),
+            new Schema\Field('test2', new Int8())
+        );
+
+        $this->expectException(SchemaValidationFailure::class);
+        $this->expectExceptionMessage('value for field "test2": 130 is not between expected range');
+        $this->expectExceptionCode(0);
+
+        $schema->validate(['test1' => 10, 'test2' => 130]);
+    }
+}


### PR DESCRIPTION
This provides the schema object, to be used to encode/decode requests and responses.